### PR TITLE
fix: prevent "undefined" arg from being passed to scripts

### DIFF
--- a/packages/cli/src/internal/launcherCommon.ts
+++ b/packages/cli/src/internal/launcherCommon.ts
@@ -146,15 +146,17 @@ export async function executeScript(scriptCommand: string, args?: string) {
 
     console.log(`========== Executing script: ${chalk.bgGrey.greenBright(script)} ==========`);
 
+    const argsString = args ? ` ${args}` : "";
+    
     switch (ext) {
       case ".js":
-        execSync(`node ${scriptPath} ${args}`, { stdio: "inherit" });
+        execSync(`node ${scriptPath}${argsString}`, { stdio: "inherit" });
         break;
       case ".ts":
-        execSync(`pnpm tsx ${scriptPath} ${args}`, { stdio: "inherit" });
+        execSync(`pnpm tsx ${scriptPath}${argsString}`, { stdio: "inherit" });
         break;
       case ".sh":
-        execSync(`${scriptPath} ${args}`, { stdio: "inherit" });
+        execSync(`${scriptPath}${argsString}`, { stdio: "inherit" });
         break;
       default:
         console.log(`${ext} not supported, skipping ${script}`);

--- a/packages/cli/src/internal/launcherCommon.ts
+++ b/packages/cli/src/internal/launcherCommon.ts
@@ -147,7 +147,6 @@ export async function executeScript(scriptCommand: string, args?: string) {
     console.log(`========== Executing script: ${chalk.bgGrey.greenBright(script)} ==========`);
 
     const argsString = args ? ` ${args}` : "";
-    
     switch (ext) {
       case ".js":
         execSync(`node ${scriptPath}${argsString}`, { stdio: "inherit" });


### PR DESCRIPTION
Fixes issue where scripts executed via runScripts received "undefined" as an argument when no arguments were provided.

The executeScript function was concatenating the args parameter even when it was undefined, resulting in the literal string "undefined" being passed to scripts.

This fix adds conditional handling to only include arguments when they are actually provided.

Closes #471

Generated with [Claude Code](https://claude.ai/code)