### PR TITLE
Fixed version inconsistency for vitest lib

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,7 +426,7 @@ importers:
         specifier: '*'
         version: 17.0.33
       '@vitest/ui':
-        specifier: ^3.1.3
+        specifier: 3.1.3
         version: 3.1.3(vitest@3.1.3)
       chai:
         specifier: 5.2.0

--- a/test/package.json
+++ b/test/package.json
@@ -29,7 +29,7 @@
     "@polkadot/util": "^13.4.4",
     "@types/node": "^22.15.19",
     "@types/yargs": "*",
-    "@vitest/ui": "^3.1.3",
+    "@vitest/ui": "3.1.3",
     "chai": "5.2.0",
     "chalk": "*",
     "ethers": "^6.14.1",


### PR DESCRIPTION
**Description**:
This PR specifies the concrete version for `vitest` core and `vitest/ui`, because having prefix `^` can lead to the greater major version resolution and, as a result, can break the suite, like we had in our case.
In the vitest `3.2` they [introduced](https://vitest.dev/blog/vitest-3-2.html#annotation-api) the new annotations API, and it broke the test suite.
Moving forward, those 2 libs should be updated synchronously. 