### PR TITLE
Account for shard offset within the `run` subcommand

### DIFF
--- a/packages/cli/src/cmds/entrypoint.ts
+++ b/packages/cli/src/cmds/entrypoint.ts
@@ -1,4 +1,5 @@
 import "@moonbeam-network/api-augment";
+import chalk from "chalk";
 import dotenv from "dotenv";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -170,7 +171,7 @@ yargs(hideBin(process.argv))
     (yargs) => {
       return yargs
         .positional("envName", {
-          describe: "Network environment to start",
+          describe: "Network environment to start. Must be defined in the global config file.",
         })
         .positional("GrepTest", {
           type: "string",
@@ -183,6 +184,11 @@ yargs(hideBin(process.argv))
         });
     },
     async (argv) => {
+      if (!argv.envName) {
+        console.error(chalk.red.bold("\n❌ Missing environment name"));
+        console.error(chalk.yellow("You must specify an environment to run."));
+        process.exit(1);
+      }
       process.env.MOON_RUN_SCRIPTS = "true";
       await runNetworkCmd(argv);
     }

--- a/packages/cli/src/cmds/entrypoint.ts
+++ b/packages/cli/src/cmds/entrypoint.ts
@@ -172,6 +172,7 @@ yargs(hideBin(process.argv))
       return yargs
         .positional("envName", {
           describe: "Network environment to start. Must be defined in the global config file.",
+          type: "string",
         })
         .positional("GrepTest", {
           type: "string",
@@ -184,11 +185,6 @@ yargs(hideBin(process.argv))
         });
     },
     async (argv) => {
-      if (!argv.envName) {
-        console.error(chalk.red.bold("\n❌ Missing environment name"));
-        console.error(chalk.yellow("You must specify an environment to run."));
-        process.exit(1);
-      }
       process.env.MOON_RUN_SCRIPTS = "true";
       await runNetworkCmd(argv);
     }

--- a/packages/cli/src/cmds/runNetwork.tsx
+++ b/packages/cli/src/cmds/runNetwork.tsx
@@ -14,6 +14,7 @@ import {
   loadEnvVars,
 } from "../lib/configReader";
 import { MoonwallContext, runNetworkOnly } from "../lib/globalContext";
+import { shardManager } from "../lib/shardManager";
 import {
   resolveChopsticksInteractiveCmdChoice,
   resolveDevInteractiveCmdChoice,
@@ -32,11 +33,8 @@ export async function runNetworkCmd(args: RunCommandArgs) {
     process.env.MOON_SUBDIR = args.subDirectory;
   }
 
-  // Set default shard information for consistent port allocation
-  // This ensures the run command uses the same port allocation logic as test command
-  if (!process.env.MOONWALL_TEST_SHARD) {
-    process.env.MOONWALL_TEST_SHARD = "1/1";
-  }
+  // Initialize shard configuration (defaults to no sharding for run command)
+  shardManager.initializeSharding();
   const globalConfig = await importAsyncConfig();
   const env = globalConfig.environments.find(({ name }) => name === args.envName);
 

--- a/packages/cli/src/cmds/runNetwork.tsx
+++ b/packages/cli/src/cmds/runNetwork.tsx
@@ -31,6 +31,12 @@ export async function runNetworkCmd(args: RunCommandArgs) {
   if (args.subDirectory) {
     process.env.MOON_SUBDIR = args.subDirectory;
   }
+
+  // Set default shard information for consistent port allocation
+  // This ensures the run command uses the same port allocation logic as test command
+  if (!process.env.MOONWALL_TEST_SHARD) {
+    process.env.MOONWALL_TEST_SHARD = "1/1";
+  }
   const globalConfig = await importAsyncConfig();
   const env = globalConfig.environments.find(({ name }) => name === args.envName);
 

--- a/packages/cli/src/cmds/runNetwork.tsx
+++ b/packages/cli/src/cmds/runNetwork.tsx
@@ -40,9 +40,9 @@ export async function runNetworkCmd(args: RunCommandArgs) {
 
   if (!env) {
     const envList = globalConfig.environments
-      .map((env) => env.name)
+      .map(env => env.name)
       .sort()
-      .join(", ");
+      .join(', ');
     throw new Error(
       `No environment found in config for: ${chalk.bgWhiteBright.blackBright(
         args.envName

--- a/packages/cli/src/cmds/runNetwork.tsx
+++ b/packages/cli/src/cmds/runNetwork.tsx
@@ -35,15 +35,13 @@ export async function runNetworkCmd(args: RunCommandArgs) {
   const env = globalConfig.environments.find(({ name }) => name === args.envName);
 
   if (!env) {
-    const envList = globalConfig.environments
-      .map(env => env.name)
-      .sort()
-      .join(', ');
-    throw new Error(
-      `No environment found in config for: ${chalk.bgWhiteBright.blackBright(
-        args.envName
-      )}\n Environments defined in config are: ${envList}\n`
-    );
+    console.error(chalk.red.bold('\n❌ Environment not found'));
+    console.error(chalk.yellow(`Environment "${args.envName || 'undefined'}" is not defined in your configuration.`));
+    console.error(chalk.cyan('\nAvailable environments:'));
+    globalConfig.environments.forEach(env => {
+      console.error(chalk.gray(`  • ${env.name}`));
+    });
+    process.exit(1);
   }
 
   loadEnvVars();

--- a/packages/cli/src/cmds/runNetwork.tsx
+++ b/packages/cli/src/cmds/runNetwork.tsx
@@ -39,13 +39,15 @@ export async function runNetworkCmd(args: RunCommandArgs) {
   const env = globalConfig.environments.find(({ name }) => name === args.envName);
 
   if (!env) {
-    console.error(chalk.red.bold('\n❌ Environment not found'));
-    console.error(chalk.yellow(`Environment "${args.envName || 'undefined'}" is not defined in your configuration.`));
-    console.error(chalk.cyan('\nAvailable environments:'));
-    globalConfig.environments.forEach(env => {
-      console.error(chalk.gray(`  • ${env.name}`));
-    });
-    process.exit(1);
+    const envList = globalConfig.environments
+      .map((env) => env.name)
+      .sort()
+      .join(", ");
+    throw new Error(
+      `No environment found in config for: ${chalk.bgWhiteBright.blackBright(
+        args.envName
+      )}\n Environments defined in config are: ${envList}\n`
+    );
   }
 
   loadEnvVars();

--- a/packages/cli/src/cmds/runTests.ts
+++ b/packages/cli/src/cmds/runTests.ts
@@ -8,6 +8,7 @@ import { clearNodeLogs } from "../internal/cmdFunctions/tempLogs";
 import { commonChecks } from "../internal/launcherCommon";
 import { cacheConfig, importAsyncConfig, loadEnvVars } from "../lib/configReader";
 import { MoonwallContext, contextCreator, runNetworkOnly } from "../lib/globalContext";
+import { shardManager } from "../lib/shardManager";
 const logger = createLogger({ name: "runner" });
 
 export async function testCmd(envName: string, additionalArgs?: testRunArgs): Promise<boolean> {
@@ -16,10 +17,8 @@ export async function testCmd(envName: string, additionalArgs?: testRunArgs): Pr
   const env = globalConfig.environments.find(({ name }) => name === envName);
   process.env.MOON_TEST_ENV = envName;
 
-  // Set shard information for improved port allocation
-  if (additionalArgs?.shard) {
-    process.env.MOONWALL_TEST_SHARD = additionalArgs.shard;
-  }
+  // Initialize sharding configuration
+  shardManager.initializeSharding(additionalArgs?.shard);
 
   if (!env) {
     const envList = globalConfig.environments

--- a/packages/cli/src/internal/commandParsers.ts
+++ b/packages/cli/src/internal/commandParsers.ts
@@ -261,9 +261,10 @@ export const getFreePort = async (): Promise<number> => {
   let shardIndex = 0;
   let totalShards = 1;
 
-  // Check for MOONWALL_TEST_SHARD environment variable (set from --ts parameter)
-  const testShard = process.env.MOONWALL_TEST_SHARD;
-  if (testShard?.includes("/")) {
+  // Check for MOONWALL_TEST_SHARD environment variable (set from --ts parameter in test command)
+  // For run command or when not set, we'll use default values (shard 1 of 1)
+  const testShard = process.env.MOONWALL_TEST_SHARD || "1/1";
+  if (testShard.includes("/")) {
     const [current, total] = testShard.split("/");
     shardIndex = parseInt(current, 10) - 1; // Convert to 0-based index
     totalShards = parseInt(total, 10);

--- a/packages/cli/src/internal/commandParsers.ts
+++ b/packages/cli/src/internal/commandParsers.ts
@@ -10,6 +10,7 @@ import chalk from "chalk";
 import path from "node:path";
 import net from "node:net";
 import { standardRepos } from "../lib/repoDefinitions";
+import { shardManager } from "../lib/shardManager";
 import invariant from "tiny-invariant";
 
 export function parseZombieCmd(launchSpec: ZombieLaunchSpec) {
@@ -257,18 +258,9 @@ const getNextAvailablePort = async (startPort: number): Promise<number> => {
  * Uses async port allocation for better collision avoidance
  */
 export const getFreePort = async (): Promise<number> => {
-  // Parse shard information from environment variables if available
-  let shardIndex = 0;
-  let totalShards = 1;
-
-  // Check for MOONWALL_TEST_SHARD environment variable (set from --ts parameter in test command)
-  // For run command or when not set, we'll use default values (shard 1 of 1)
-  const testShard = process.env.MOONWALL_TEST_SHARD || "1/1";
-  if (testShard.includes("/")) {
-    const [current, total] = testShard.split("/");
-    shardIndex = parseInt(current, 10) - 1; // Convert to 0-based index
-    totalShards = parseInt(total, 10);
-  }
+  // Get shard information from centralized manager
+  const shardIndex = shardManager.getShardIndex();
+  const totalShards = shardManager.getTotalShards();
 
   // Use VITEST_POOL_ID as additional offset if available
   const poolId = parseInt(process.env.VITEST_POOL_ID || "0", 10);

--- a/packages/cli/src/internal/providerFactories.ts
+++ b/packages/cli/src/internal/providerFactories.ts
@@ -123,10 +123,10 @@ export class ProviderFactory {
           return client;
         } catch (error: any) {
           console.error(
-            `❌ Failed to create viem provider ${this.providerConfig.name}: ${error.message}`
+            `❌ Failed to create viem provider ${this.providerConfig.name} at ${this.url}: ${error.message}`
           );
           throw new Error(
-            `Viem provider initialization failed for ${this.providerConfig.name}: ${error.message}`
+            `Viem provider initialization failed for ${this.providerConfig.name} at ${this.url}: ${error.message}`
           );
         }
       },

--- a/packages/cli/src/lib/shardManager.ts
+++ b/packages/cli/src/lib/shardManager.ts
@@ -1,0 +1,105 @@
+interface ShardInfo {
+  readonly current: number;
+  readonly total: number;
+  readonly isSharded: boolean;
+}
+
+export class ShardManager {
+  private static instance: ShardManager | null = null;
+  private _shardInfo: ShardInfo | null = null;
+
+  private constructor() {}
+
+  static getInstance(): ShardManager {
+    if (!ShardManager.instance) {
+      ShardManager.instance = new ShardManager();
+    }
+    return ShardManager.instance;
+  }
+
+  /**
+   * Initialize shard configuration from command line argument or environment
+   * @param shardArg Optional shard argument from CLI (format: "current/total")
+   */
+  initializeSharding(shardArg?: string): void {
+    if (shardArg) {
+      this._shardInfo = this.parseShardString(shardArg);
+      process.env.MOONWALL_TEST_SHARD = shardArg;
+    } else if (process.env.MOONWALL_TEST_SHARD) {
+      this._shardInfo = this.parseShardString(process.env.MOONWALL_TEST_SHARD);
+    } else {
+      // Default: no sharding
+      this._shardInfo = { current: 1, total: 1, isSharded: false };
+    }
+  }
+
+  /**
+   * Get current shard information
+   */
+  getShardInfo(): ShardInfo {
+    if (!this._shardInfo) {
+      this.initializeSharding();
+    }
+    return this._shardInfo as ShardInfo;
+  }
+
+  /**
+   * Get shard index (0-based) for port calculations
+   */
+  getShardIndex(): number {
+    return this.getShardInfo().current - 1;
+  }
+
+  /**
+   * Get total number of shards
+   */
+  getTotalShards(): number {
+    return this.getShardInfo().total;
+  }
+
+  /**
+   * Check if sharding is enabled
+   */
+  isSharded(): boolean {
+    return this.getShardInfo().isSharded;
+  }
+
+  /**
+   * Reset shard configuration (mainly for testing)
+   */
+  reset(): void {
+    this._shardInfo = null;
+    delete process.env.MOONWALL_TEST_SHARD;
+  }
+
+  private parseShardString(shardString: string): ShardInfo {
+    if (!shardString.includes("/")) {
+      throw new Error(
+        `Invalid shard format: "${shardString}". Expected format: "current/total" (e.g., "1/3")`
+      );
+    }
+
+    const [currentStr, totalStr] = shardString.split("/");
+    const current = parseInt(currentStr, 10);
+    const total = parseInt(totalStr, 10);
+
+    if (Number.isNaN(current) || Number.isNaN(total) || current < 1 || total < 1) {
+      throw new Error(
+        `Invalid shard numbers in "${shardString}". Both current and total must be positive integers.`
+      );
+    }
+
+    if (current > total) {
+      throw new Error(
+        `Invalid shard configuration: current shard ${current} cannot be greater than total ${total}`
+      );
+    }
+
+    const isSharded = total > 1;
+
+    return { current, total, isSharded };
+  }
+}
+
+// Export singleton instance for convenience
+export const shardManager = ShardManager.getInstance();

--- a/packages/util/src/functions/common.ts
+++ b/packages/util/src/functions/common.ts
@@ -156,7 +156,8 @@ export async function directRpcRequest(
         `RPC request to ${endpoint} timed out after ${timeoutMs}ms (method: ${method})`
       );
     }
-    throw error;
+    // Add context to fetch errors
+    throw new Error(`RPC request to ${endpoint} failed (method: ${method}): ${error.message}`);
   }
 }
 

--- a/packages/util/src/functions/viem.ts
+++ b/packages/util/src/functions/viem.ts
@@ -104,7 +104,7 @@ export async function deriveViemChain(endpoint: string, maxRetries: number = 3) 
       lastError = error;
       if (attempt < maxRetries) {
         console.warn(
-          `Failed to derive viem chain on attempt ${attempt}/${maxRetries}: ${error.message}. Retrying...`
+          `Failed to derive viem chain on attempt ${attempt}/${maxRetries} from ${httpEndpoint}: ${error.message}. Retrying...`
         );
         await timer(1000 * attempt); // Linear backoff
       }
@@ -112,7 +112,7 @@ export async function deriveViemChain(endpoint: string, maxRetries: number = 3) 
   }
 
   throw new Error(
-    `Failed to derive viem chain after ${maxRetries} attempts: ${lastError?.message || "Unknown error"}`
+    `Failed to derive viem chain after ${maxRetries} attempts from ${httpEndpoint}: ${lastError?.message || "Unknown error"}`
   );
 }
 


### PR DESCRIPTION
## Description

Moonwall's `run` subcommand stopped working due to port mismatch introduced in https://github.com/Moonsong-Labs/moonwall/pull/498.
This PR fixes the issue by accounting for shard offset within the `run` subcommand.

- Use singleton class instead of environment variable to manage sharding.
- Adds port information to error logs to allow checking for port mismatches.
