### PR TITLE
fix(cli): avoid substring matches when checking running nodes

### DIFF
--- a/packages/cli/src/internal/fileCheckers.ts
+++ b/packages/cli/src/internal/fileCheckers.ts
@@ -106,7 +106,7 @@ export function checkAlreadyRunning(binaryName: string): number[] {
   try {
     console.log(`Checking if ${chalk.bgWhiteBright.blackBright(binaryName)} is already running...`);
     // pgrep only supports 15 characters
-    const stdout = execSync(`pgrep ${[binaryName.slice(0, 14)]}`, {
+    const stdout = execSync(`pgrep -x ${[binaryName.slice(0, 14)]}`, {
       encoding: "utf8",
       timeout: 2000,
     });


### PR DESCRIPTION
## Summary
- ensure the running process detection uses exact name matches to avoid substring collisions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b6cdb26dc83318b585dc6d569af9e