### PR TITLE
refactor: Use chopsticks native config

### DIFF
--- a/packages/cli/src/internal/effect/ChopsticksMultiChain.ts
+++ b/packages/cli/src/internal/effect/ChopsticksMultiChain.ts
@@ -7,6 +7,7 @@
 
 import { Context, Data, Effect, Layer } from "effect";
 import type { HexString } from "@polkadot/util/types";
+import type { BuildBlockMode } from "@acala-network/chopsticks";
 import { createLogger } from "@moonwall/util";
 import {
   type ChopsticksConfig,
@@ -18,6 +19,16 @@ import {
 import { type ChopsticksServiceImpl, launchChopsticksEffect } from "./launchChopsticksEffect.js";
 
 const logger = createLogger({ name: "ChopsticksMultiChain" });
+
+/**
+ * Extract a single endpoint string from the config.
+ * The ChopsticksConfig endpoint can be a string, array of strings, or undefined.
+ */
+const getEndpointString = (endpoint: string | string[] | undefined): string | undefined => {
+  if (typeof endpoint === "string") return endpoint;
+  if (Array.isArray(endpoint)) return endpoint[0];
+  return undefined;
+};
 
 // =============================================================================
 // Error Types
@@ -352,7 +363,7 @@ export const ChopsticksMultiChainLayer = (
         catch: (cause) =>
           new ChopsticksSetupError({
             cause,
-            endpoint: config.relay.endpoint,
+            endpoint: getEndpointString(config.relay.endpoint),
           }),
       });
       cleanups.push(
@@ -370,7 +381,7 @@ export const ChopsticksMultiChainLayer = (
           catch: (cause) =>
             new ChopsticksSetupError({
               cause,
-              endpoint: paraConfig.endpoint,
+              endpoint: getEndpointString(paraConfig.endpoint),
             }),
         });
         cleanups.push(
@@ -412,6 +423,7 @@ export const createPolkadotMoonbeamConfig = (
     type: "relay",
     endpoint: "wss://rpc.polkadot.io",
     port: relayPort,
+    "build-block-mode": "Manual" as BuildBlockMode,
   },
   parachains: [
     {
@@ -419,6 +431,7 @@ export const createPolkadotMoonbeamConfig = (
       paraId: 2004, // Moonbeam on Polkadot
       endpoint: "wss://wss.api.moonbeam.network",
       port: moonbeamPort,
+      "build-block-mode": "Manual" as BuildBlockMode,
     },
   ],
 });
@@ -438,6 +451,7 @@ export const createKusamaMoonriverConfig = (
     type: "relay",
     endpoint: "wss://kusama-rpc.polkadot.io",
     port: relayPort,
+    "build-block-mode": "Manual" as BuildBlockMode,
   },
   parachains: [
     {
@@ -445,6 +459,7 @@ export const createKusamaMoonriverConfig = (
       paraId: 2023, // Moonriver on Kusama
       endpoint: "wss://wss.api.moonriver.moonbeam.network",
       port: moonriverPort,
+      "build-block-mode": "Manual" as BuildBlockMode,
     },
   ],
 });

--- a/packages/cli/src/internal/effect/ChopsticksService.ts
+++ b/packages/cli/src/internal/effect/ChopsticksService.ts
@@ -3,11 +3,23 @@
  *
  * This service provides a type-safe, Effect-based interface to @acala-network/chopsticks,
  * replacing the previous CLI-subprocess approach with direct programmatic control.
+ *
+ * The configuration type (ChopsticksConfig) is imported directly from @acala-network/chopsticks
+ * to ensure it stays in sync with upstream changes and supports all config options like rpc-timeout.
  */
 
 import { Context, Data, Effect } from "effect";
-import type { Blockchain, BuildBlockMode } from "@acala-network/chopsticks";
+import type { Blockchain, BuildBlockMode, fetchConfig } from "@acala-network/chopsticks";
 import type { HexString } from "@polkadot/util/types";
+
+/**
+ * The ChopsticksConfig type, derived from the fetchConfig return type.
+ *
+ * This ensures our type stays in sync with upstream chopsticks changes.
+ * The config uses kebab-case keys as defined by chopsticks (e.g., 'rpc-timeout',
+ * 'build-block-mode', 'mock-signature-host').
+ */
+export type ChopsticksConfig = Awaited<ReturnType<typeof fetchConfig>>;
 
 // =============================================================================
 // Error Types
@@ -79,34 +91,6 @@ export type ChopsticksError =
 // =============================================================================
 // Configuration Types
 // =============================================================================
-
-/**
- * Configuration for launching a chopsticks instance
- */
-export interface ChopsticksConfig {
-  /** WebSocket endpoint to fork from (e.g., "wss://rpc.polkadot.io") */
-  readonly endpoint: string;
-  /** Block number or hash to fork from (defaults to latest finalized) */
-  readonly block?: string | number | null;
-  /** Port to listen on (defaults to 8000) */
-  readonly port?: number;
-  /** Host to bind to (defaults to "127.0.0.1") */
-  readonly host?: string;
-  /** Block building mode: "batch" | "manual" | "instant" */
-  readonly buildBlockMode?: BuildBlockMode;
-  /** Path to WASM override file */
-  readonly wasmOverride?: string;
-  /** Whether to allow unresolved imports in WASM */
-  readonly allowUnresolvedImports?: boolean;
-  /** Whether to mock signature verification */
-  readonly mockSignatureHost?: boolean;
-  /** Path to SQLite database for caching */
-  readonly db?: string;
-  /** Storage overrides to apply */
-  readonly importStorage?: Record<string, Record<string, unknown>>;
-  /** Runtime log level (0-5) */
-  readonly runtimeLogLevel?: number;
-}
 
 /**
  * Result from creating a new block

--- a/packages/cli/src/internal/effect/__tests__/ChopsticksMultiChain.test.ts
+++ b/packages/cli/src/internal/effect/__tests__/ChopsticksMultiChain.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Effect, Layer } from "effect";
+import { BuildBlockMode } from "@acala-network/chopsticks";
 import {
   ChopsticksOrchestrationError,
   ChopsticksMultiChainService,
@@ -83,35 +84,38 @@ describe("ChopsticksMultiChain - Phase 4: Multi-chain XCM Support", () => {
   });
 
   describe("Configuration Types", () => {
-    it("should create valid RelayChainConfig", () => {
+    it("should create valid RelayChainConfig with kebab-case keys", () => {
       const config: RelayChainConfig = {
         type: "relay",
         endpoint: "wss://rpc.polkadot.io",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       };
 
       expect(config.type).toBe("relay");
       expect(config.endpoint).toBe("wss://rpc.polkadot.io");
     });
 
-    it("should create valid ParachainConfig", () => {
+    it("should create valid ParachainConfig with kebab-case keys", () => {
       const config: ParachainConfig = {
         type: "parachain",
         paraId: 2000,
         endpoint: "wss://moonbeam.rpc.io",
         port: 8001,
+        "build-block-mode": BuildBlockMode.Manual,
       };
 
       expect(config.type).toBe("parachain");
       expect(config.paraId).toBe(2000);
     });
 
-    it("should create valid MultiChainConfig", () => {
+    it("should create valid MultiChainConfig with kebab-case keys", () => {
       const config: MultiChainConfig = {
         relay: {
           type: "relay",
           endpoint: "wss://rpc.polkadot.io",
           port: 8000,
+          "build-block-mode": BuildBlockMode.Manual,
         },
         parachains: [
           {
@@ -119,12 +123,14 @@ describe("ChopsticksMultiChain - Phase 4: Multi-chain XCM Support", () => {
             paraId: 2000,
             endpoint: "wss://moonbeam.rpc.io",
             port: 8001,
+            "build-block-mode": BuildBlockMode.Manual,
           },
           {
             type: "parachain",
             paraId: 2001,
             endpoint: "wss://acala.rpc.io",
             port: 8002,
+            "build-block-mode": BuildBlockMode.Manual,
           },
         ],
       };
@@ -364,6 +370,7 @@ describe("ChopsticksMultiChain - Phase 4: Multi-chain XCM Support", () => {
           type: "relay",
           endpoint: "wss://test.io",
           port: 8000,
+          "build-block-mode": BuildBlockMode.Manual,
         },
         parachains: [
           {
@@ -371,6 +378,7 @@ describe("ChopsticksMultiChain - Phase 4: Multi-chain XCM Support", () => {
             paraId: 2000,
             endpoint: "wss://para.test.io",
             port: 8001,
+            "build-block-mode": BuildBlockMode.Manual,
           },
         ],
       };
@@ -389,6 +397,7 @@ describe("ChopsticksMultiChain - Phase 4: Multi-chain XCM Support", () => {
           type: "relay",
           endpoint: "wss://test.io",
           port: 8000,
+          "build-block-mode": BuildBlockMode.Manual,
         },
         parachains: [],
       };
@@ -444,6 +453,7 @@ describe.skip("ChopsticksMultiChain - Integration Tests", () => {
         type: "relay",
         endpoint: "wss://rpc.polkadot.io",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       },
       parachains: [
         {
@@ -451,6 +461,7 @@ describe.skip("ChopsticksMultiChain - Integration Tests", () => {
           paraId: 2004,
           endpoint: "wss://wss.api.moonbeam.network",
           port: 8001,
+          "build-block-mode": BuildBlockMode.Manual,
         },
       ],
     });

--- a/packages/cli/src/internal/effect/__tests__/ChopsticksService.test.ts
+++ b/packages/cli/src/internal/effect/__tests__/ChopsticksService.test.ts
@@ -218,39 +218,46 @@ describe("ChopsticksService - Phase 1: Types and Errors", () => {
   });
 
   describe("Config Type Validation", () => {
-    it("should allow creating a valid ChopsticksConfig", () => {
+    it("should allow creating a valid ChopsticksConfig with kebab-case keys", () => {
+      // ChopsticksConfig uses kebab-case keys matching chopsticks' native format
       const config: ChopsticksConfig = {
         endpoint: "wss://rpc.polkadot.io",
         block: 12345,
         port: 8000,
         host: "127.0.0.1",
-        buildBlockMode: BuildBlockMode.Manual,
-        wasmOverride: "/path/to/wasm",
-        allowUnresolvedImports: true,
-        mockSignatureHost: true,
+        "build-block-mode": BuildBlockMode.Manual,
+        "wasm-override": "/path/to/wasm",
+        "allow-unresolved-imports": true,
+        "mock-signature-host": true,
         db: "./chopsticks.db",
-        runtimeLogLevel: 3,
+        "runtime-log-level": 3,
+        "rpc-timeout": 30000, // New field supported via chopsticks type
       };
 
       expect(config.endpoint).toBe("wss://rpc.polkadot.io");
       expect(config.block).toBe(12345);
       expect(config.port).toBe(8000);
+      expect(config["rpc-timeout"]).toBe(30000);
     });
 
-    it("should allow minimal ChopsticksConfig with only required fields", () => {
+    it("should allow ChopsticksConfig with required port and build-block-mode", () => {
+      // The chopsticks Config type has port and build-block-mode as required after parsing
       const config: ChopsticksConfig = {
         endpoint: "wss://rpc.polkadot.io",
+        port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       };
 
       expect(config.endpoint).toBe("wss://rpc.polkadot.io");
-      expect(config.block).toBeUndefined();
-      expect(config.port).toBeUndefined();
+      expect(config.port).toBe(8000);
+      expect(config["build-block-mode"]).toBe(BuildBlockMode.Manual);
     });
 
     it("should allow providing ChopsticksConfig via Layer", async () => {
       const config: ChopsticksConfig = {
         endpoint: "wss://test.io",
         port: 9000,
+        "build-block-mode": BuildBlockMode.Manual,
       };
 
       const configLayer = Layer.succeed(ChopsticksConfigTag, config);

--- a/packages/cli/src/internal/effect/__tests__/launchChopsticksEffect.test.ts
+++ b/packages/cli/src/internal/effect/__tests__/launchChopsticksEffect.test.ts
@@ -177,47 +177,54 @@ describe("launchChopsticksEffect - Phase 2: Module Structure", () => {
     });
   });
 
-  describe("Config Conversion", () => {
-    it("should accept minimal config with only endpoint", () => {
+  describe("Config Conversion (kebab-case)", () => {
+    it("should accept config with required fields", () => {
+      // ChopsticksConfig now uses kebab-case keys and has port/build-block-mode as required
       const config: ChopsticksConfig = {
         endpoint: "wss://rpc.polkadot.io",
+        port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       };
 
       expect(config.endpoint).toBe("wss://rpc.polkadot.io");
-      expect(config.port).toBeUndefined();
-      expect(config.host).toBeUndefined();
+      expect(config.port).toBe(8000);
+      expect(config["build-block-mode"]).toBe(BuildBlockMode.Manual);
     });
 
-    it("should accept full config with all options", () => {
+    it("should accept full config with all options using kebab-case", () => {
       const config: ChopsticksConfig = {
         endpoint: "wss://rpc.polkadot.io",
         block: 12345,
         port: 9000,
         host: "0.0.0.0",
-        buildBlockMode: BuildBlockMode.Manual,
-        wasmOverride: "/path/to/wasm",
-        allowUnresolvedImports: true,
-        mockSignatureHost: true,
+        "build-block-mode": BuildBlockMode.Manual,
+        "wasm-override": "/path/to/wasm",
+        "allow-unresolved-imports": true,
+        "mock-signature-host": true,
         db: "./chopsticks.db",
-        importStorage: { System: { Account: {} } },
-        runtimeLogLevel: 3,
+        "import-storage": { System: { Account: {} } },
+        "runtime-log-level": 3,
+        "rpc-timeout": 30000, // New field supported via chopsticks type
       };
 
       expect(config.endpoint).toBe("wss://rpc.polkadot.io");
       expect(config.block).toBe(12345);
       expect(config.port).toBe(9000);
       expect(config.host).toBe("0.0.0.0");
-      expect(config.buildBlockMode).toBe(BuildBlockMode.Manual);
-      expect(config.wasmOverride).toBe("/path/to/wasm");
-      expect(config.allowUnresolvedImports).toBe(true);
-      expect(config.mockSignatureHost).toBe(true);
+      expect(config["build-block-mode"]).toBe(BuildBlockMode.Manual);
+      expect(config["wasm-override"]).toBe("/path/to/wasm");
+      expect(config["allow-unresolved-imports"]).toBe(true);
+      expect(config["mock-signature-host"]).toBe(true);
       expect(config.db).toBe("./chopsticks.db");
-      expect(config.runtimeLogLevel).toBe(3);
+      expect(config["runtime-log-level"]).toBe(3);
+      expect(config["rpc-timeout"]).toBe(30000);
     });
 
     it("should accept config with block as hash string", () => {
       const config: ChopsticksConfig = {
         endpoint: "wss://rpc.polkadot.io",
+        port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
         block: "0x1234567890abcdef",
       };
 
@@ -227,6 +234,8 @@ describe("launchChopsticksEffect - Phase 2: Module Structure", () => {
     it("should accept config with block as null for latest", () => {
       const config: ChopsticksConfig = {
         endpoint: "wss://rpc.polkadot.io",
+        port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
         block: null,
       };
 
@@ -241,6 +250,7 @@ describe("launchChopsticksEffect - Phase 2: Module Structure", () => {
       const program = launchChopsticksEffectProgram({
         endpoint: "wss://test.io",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       });
 
       // Verify it's an Effect by checking it has common Effect methods
@@ -254,6 +264,7 @@ describe("launchChopsticksEffect - Phase 2: Module Structure", () => {
       const program = launchChopsticksEffectProgram({
         endpoint: "wss://nonexistent.invalid",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       }).pipe(
         Effect.catchTag("ChopsticksSetupError", (error) =>
           Effect.succeed({ caught: true, endpoint: error.endpoint })
@@ -324,6 +335,7 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
       const layer = ChopsticksServiceLayer({
         endpoint: "wss://test.io",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       });
 
       // Verify it's a Layer by checking it has Layer-like structure
@@ -338,6 +350,7 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
       const layer = ChopsticksServiceLayer({
         endpoint: "wss://test.io",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       });
 
       // Verify the Layer is typed to provide ChopsticksService
@@ -352,7 +365,7 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
       expect(typeof providedProgram.pipe).toBe("function");
     });
 
-    it("should accept all config options", async () => {
+    it("should accept all config options using kebab-case", async () => {
       const { ChopsticksServiceLayer } = await import("../launchChopsticksEffect.js");
       const { BuildBlockMode } = await import("@acala-network/chopsticks");
 
@@ -361,12 +374,13 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
         block: 12345,
         port: 9000,
         host: "0.0.0.0",
-        buildBlockMode: BuildBlockMode.Manual,
-        wasmOverride: "/path/to/wasm",
-        allowUnresolvedImports: true,
-        mockSignatureHost: true,
+        "build-block-mode": BuildBlockMode.Manual,
+        "wasm-override": "/path/to/wasm",
+        "allow-unresolved-imports": true,
+        "mock-signature-host": true,
         db: "./chopsticks.db",
-        runtimeLogLevel: 3,
+        "runtime-log-level": 3,
+        "rpc-timeout": 30000,
       });
 
       expect(layer).toBeDefined();
@@ -383,6 +397,7 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
       const configLayer = Layer.succeed(ChopsticksConfigTag, {
         endpoint: "wss://test.io",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       });
 
       const program = Effect.gen(function* () {
@@ -406,6 +421,7 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
       const configLayer = Layer.succeed(ChopsticksConfigTag, {
         endpoint: "wss://test.io",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       });
 
       // Compose with ChopsticksServiceLive
@@ -423,6 +439,7 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
       const layer = ChopsticksServiceLayer({
         endpoint: "wss://nonexistent.invalid",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       });
 
       const program = Effect.gen(function* () {
@@ -447,6 +464,7 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
       const configLayer = Layer.succeed(ChopsticksConfigTag, {
         endpoint: "wss://nonexistent.invalid",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       });
 
       const fullLayer = ChopsticksServiceLive.pipe(Layer.provide(configLayer));
@@ -473,6 +491,7 @@ describe("ChopsticksServiceLayer - Phase 3: Layer.scoped", () => {
       const layer = ChopsticksServiceLayer({
         endpoint: "wss://test.io",
         port: 8000,
+        "build-block-mode": BuildBlockMode.Manual,
       });
 
       // Effect.scoped can be used to manually control the scope
@@ -502,7 +521,7 @@ describe.skip("launchChopsticksEffect - Integration Tests", () => {
     const { result, cleanup } = await launchChopsticksEffect({
       endpoint: "wss://rpc.polkadot.io",
       port: 8000,
-      buildBlockMode: BuildBlockMode.Manual,
+      "build-block-mode": BuildBlockMode.Manual,
     });
 
     try {
@@ -520,7 +539,7 @@ describe.skip("launchChopsticksEffect - Integration Tests", () => {
     const { result, cleanup } = await launchChopsticksEffect({
       endpoint: "wss://rpc.polkadot.io",
       port: 8001,
-      buildBlockMode: BuildBlockMode.Manual,
+      "build-block-mode": BuildBlockMode.Manual,
     });
 
     try {


### PR DESCRIPTION
This pull request updates the configuration handling for the Chopsticks service to use kebab-case keys and derive types directly from upstream Chopsticks, improving type safety and compatibility. It also updates all related code and tests to use the new config format and ensures required fields (like `port` and `build-block-mode`) are present. Additionally, it introduces a utility for consistent endpoint extraction and refactors error handling to support the new config structure.

**Configuration Type Refactor**

* The `ChopsticksConfig` type is now derived from the upstream Chopsticks `fetchConfig` return type, ensuring all supported config options (like `rpc-timeout`) are available and keys use kebab-case as in Chopsticks itself. The previous hand-written interface is removed. (`packages/cli/src/internal/effect/ChopsticksService.ts`, [[1]](diffhunk://#diff-68648aff69af4b3bda9e62dd2a02dfecdd11ef7c50e4d016ce4e5134475ff76cR6-R23) [[2]](diffhunk://#diff-68648aff69af4b3bda9e62dd2a02dfecdd11ef7c50e4d016ce4e5134475ff76cL83-L110)
* All usages and tests of `ChopsticksConfig`, `RelayChainConfig`, `ParachainConfig`, and `MultiChainConfig` are updated to use kebab-case keys (e.g., `"build-block-mode"`, `"wasm-override"`) and to include required fields. (`packages/cli/src/internal/effect/__tests__/ChopsticksService.test.ts`, [[1]](diffhunk://#diff-2155227fd95ced862248ddd7735caeaec44506ecec087606892d5cc626ee17f3L221-R260); `packages/cli/src/internal/effect/__tests__/launchChopsticksEffect.test.ts`, [[2]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48L180-R227) [[3]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48R338) [[4]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48R353) [[5]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48L355-R368) [[6]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48L364-R383) [[7]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48R400); `packages/cli/src/internal/effect/__tests__/ChopsticksMultiChain.test.ts`, [[8]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eL86-R133) [[9]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eR373-R381) [[10]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eR400) [[11]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eR456-R464)

**Multi-chain Configuration Updates**

* The multi-chain configuration generators (`createPolkadotMoonbeamConfig`, `createKusamaMoonriverConfig`) now set `"build-block-mode"` as required in both relay and parachain configs using kebab-case. (`packages/cli/src/internal/effect/ChopsticksMultiChain.ts`, [[1]](diffhunk://#diff-d0e09b761489c8dacf5c92700f2aefa5a1fc8cf6e9ad6b6e8b713ecc8b9e5fc5R426-R434) [[2]](diffhunk://#diff-d0e09b761489c8dacf5c92700f2aefa5a1fc8cf6e9ad6b6e8b713ecc8b9e5fc5R454-R462)

**Error Handling and Utility Improvements**

* Introduced a new utility function `getEndpointString` to consistently extract the endpoint string from config objects, supporting string, array, or undefined values. This function is used in error handling to improve reliability. (`packages/cli/src/internal/effect/ChopsticksMultiChain.ts`, [[1]](diffhunk://#diff-d0e09b761489c8dacf5c92700f2aefa5a1fc8cf6e9ad6b6e8b713ecc8b9e5fc5R23-R32) [[2]](diffhunk://#diff-d0e09b761489c8dacf5c92700f2aefa5a1fc8cf6e9ad6b6e8b713ecc8b9e5fc5L355-R366) [[3]](diffhunk://#diff-d0e09b761489c8dacf5c92700f2aefa5a1fc8cf6e9ad6b6e8b713ecc8b9e5fc5L373-R384)

**Test Suite Modernization**

* All test cases are updated to validate the new kebab-case config format, including checks for required fields and new options like `"rpc-timeout"`. This ensures the codebase stays in sync with upstream changes and config validation is robust. (`packages/cli/src/internal/effect/__tests__/ChopsticksService.test.ts`, [[1]](diffhunk://#diff-2155227fd95ced862248ddd7735caeaec44506ecec087606892d5cc626ee17f3L221-R260); `packages/cli/src/internal/effect/__tests__/launchChopsticksEffect.test.ts`, [[2]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48L180-R227) [[3]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48R338) [[4]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48R353) [[5]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48L355-R368) [[6]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48L364-R383) [[7]](diffhunk://#diff-30029a58c80c7f94b71f64bb0a2d449731236daf311e443dda0e6f3089bbab48R400); `packages/cli/src/internal/effect/__tests__/ChopsticksMultiChain.test.ts`, [[8]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eL86-R133) [[9]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eR373-R381) [[10]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eR400) [[11]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eR456-R464)

**Dependency and Type Import Updates**

* All relevant files now import `BuildBlockMode` and related types directly from `@acala-network/chopsticks` to ensure type accuracy and compatibility. (`packages/cli/src/internal/effect/ChopsticksMultiChain.ts`, [[1]](diffhunk://#diff-d0e09b761489c8dacf5c92700f2aefa5a1fc8cf6e9ad6b6e8b713ecc8b9e5fc5R10); `packages/cli/src/internal/effect/__tests__/ChopsticksMultiChain.test.ts`, [[2]](diffhunk://#diff-2c5c0680814be8ee85bb8edc90e60b5185a37433ff6f6caeedbe725db25c068eR3)

These changes make the Chopsticks integration more robust, future-proof, and easier to maintain as upstream evolves.