### PR TITLE
Pass the `rpc-timeout` parameter further to chopsticks

### DIFF
--- a/packages/cli/src/internal/effect/chopsticksConfigParser.ts
+++ b/packages/cli/src/internal/effect/chopsticksConfigParser.ts
@@ -229,6 +229,7 @@ export const parseChopsticksConfigFile = (
       "allow-unresolved-imports":
         overrides?.allowUnresolvedImports ??
         (rawConfig["allow-unresolved-imports"] as boolean | undefined),
+      "rpc-timeout": rawConfig["rpc-timeout"] || undefined
     } as ChopsticksConfig;
 
     return config;


### PR DESCRIPTION
## Description
This PR passes the `rpc-timeout` parameter further to chopsticks 