### PR TITLE
fix: use Moonbeam Foundation endpoint to avoid rate limiting

### DIFF
--- a/test/configs/moonbeamChopsticks.yml
+++ b/test/configs/moonbeamChopsticks.yml
@@ -1,4 +1,4 @@
-endpoint: ${env.MOONBEAM_ENDPOINT}
+endpoint: wss://wss.api.moonbeam.network
 mock-signature-host: true
 port: 10000
 db: ./tmp/db_mb.sqlite


### PR DESCRIPTION
Replace OnFinality endpoint (via MOONBEAM_ENDPOINT env var) with the official Moonbeam Foundation endpoint to fix intermittent CI failures caused by RPC rate limiting in chopsticks tests.